### PR TITLE
refactor: Use ES6 class

### DIFF
--- a/lib/CountingStream.js
+++ b/lib/CountingStream.js
@@ -1,29 +1,25 @@
 'use strict';
 
-const Transform = require('stream').Transform;
-const util = require('util');
+const { Transform } = require('stream');
 
-const CountingStream = function (options) {
-  this.streamCount = 0;
+class CountingStream extends Transform {
+  constructor (options) {
+    super(options);
+    this.streamCount = 0;
+  }
 
-  Transform.call(this, options);
-};
+  _transform (chunk, encoding, callback) {
+    this.streamCount += chunk.length;
+    callback(null, chunk);
+  }
 
-util.inherits(CountingStream, Transform);
+  resetCount (count) {
+    this.streamCount = count || 0;
+  }
 
-/* eslint-disable no-underscore-dangle */
-CountingStream.prototype._transform = function (chunk, encoding, callback) {
-  this.streamCount += chunk.length;
-  callback(null, chunk);
-};
-/* eslint-enable no-underscore-dangle */
-
-CountingStream.prototype.resetCount = function (count) {
-  this.streamCount = count || 0;
-};
-
-CountingStream.prototype.getCount = function () {
-  return this.streamCount;
-};
+  getCount () {
+    return this.streamCount;
+  }
+}
 
 module.exports = CountingStream;


### PR DESCRIPTION
VScode complains about stream event methods (e.g. `emit`, `removeAllListeners`, `end`), as it can't resolve the inheritance properly. Using ES6 class notation fixes this.